### PR TITLE
Add PWA features with service worker and push support

### DIFF
--- a/frontend/Layout.tsx
+++ b/frontend/Layout.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useLocation } from 'react-router-dom';
 import { useToast } from './components/Shared/ToastContext';
 import Navbar from './components/Navbar';
 import Sidebar from './components/Sidebar';
@@ -44,6 +45,7 @@ const Layout: React.FC<LayoutProps> = ({
     children,
 }) => {
     const { t } = useTranslation();
+    const location = useLocation();
     const { showSuccessToast } = useToast();
     const [isSidebarOpen, setIsSidebarOpen] = useState(
         window.innerWidth >= 1024
@@ -109,6 +111,12 @@ const Layout: React.FC<LayoutProps> = ({
         window.addEventListener('resize', handleResize);
         return () => window.removeEventListener('resize', handleResize);
     }, []);
+
+    useEffect(() => {
+        if (document.startViewTransition) {
+            document.startViewTransition(() => {});
+        }
+    }, [location.pathname]);
 
     const loadNotes = async () => {
         setNotesLoading(true);

--- a/frontend/components/About.tsx
+++ b/frontend/components/About.tsx
@@ -1,10 +1,25 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { HeartIcon, InformationCircleIcon } from '@heroicons/react/24/outline';
 
 const About: React.FC = () => {
     const { t } = useTranslation();
     const [version, setVersion] = useState<string>('0.3');
+    const videoRef = useRef<HTMLVideoElement>(null);
+
+    const handlePiP = async () => {
+        const video = videoRef.current;
+        if (!video) return;
+        try {
+            if (document.pictureInPictureElement) {
+                await document.exitPictureInPicture();
+            } else {
+                await video.requestPictureInPicture();
+            }
+        } catch (e) {
+            console.error(e);
+        }
+    };
 
     useEffect(() => {
         // Fetch version from the deployed app
@@ -219,6 +234,27 @@ const About: React.FC = () => {
                                 )}
                             </span>
                         </div>
+                    </div>
+
+                    {/* Demo Video */}
+                    <div className="text-center my-8">
+                        <video
+                            ref={videoRef}
+                            className="mx-auto rounded-lg mb-2"
+                            width="320"
+                            controls
+                        >
+                            <source
+                                src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4"
+                                type="video/mp4"
+                            />
+                        </video>
+                        <button
+                            onClick={handlePiP}
+                            className="px-3 py-2 bg-indigo-500 hover:bg-indigo-600 text-white rounded"
+                        >
+                            PiP
+                        </button>
                     </div>
 
                     {/* Footer */}

--- a/frontend/components/Login.tsx
+++ b/frontend/components/Login.tsx
@@ -34,6 +34,9 @@ const Login: React.FC = () => {
                     new CustomEvent('userLoggedIn', { detail: data.user })
                 );
 
+                if (navigator.vibrate) {
+                    navigator.vibrate([200, 100, 200]);
+                }
                 navigate('/today');
             } else {
                 setError(data.errors[0] || 'Login failed. Please try again.');

--- a/frontend/components/Navbar.tsx
+++ b/frontend/components/Navbar.tsx
@@ -8,6 +8,8 @@ import {
 } from '@heroicons/react/24/solid';
 import { useTranslation } from 'react-i18next';
 import PomodoroTimer from './Shared/PomodoroTimer';
+import InstallButton from './Shared/InstallButton';
+import SubscribeButton from './Shared/SubscribeButton';
 
 interface NavbarProps {
     isDarkMode: boolean;
@@ -153,6 +155,8 @@ const Navbar: React.FC<NavbarProps> = ({
                         <InboxIcon className="hidden md:inline-block ml-1.5 h-4 w-4 text-blue-200" />
                     </button>
                     {pomodoroEnabled && <PomodoroTimer />}
+                    <InstallButton />
+                    <SubscribeButton />
 
                     <div className="relative" ref={dropdownRef}>
                         <button

--- a/frontend/components/Project/AutoSuggestNextActionBox.tsx
+++ b/frontend/components/Project/AutoSuggestNextActionBox.tsx
@@ -32,6 +32,9 @@ const AutoSuggestNextActionBox: React.FC<AutoSuggestNextActionBoxProps> = ({
         if (actionDescription.trim()) {
             onAddAction(actionDescription.trim());
             showSuccessToast(t('success.nextActionAdded'));
+            if (navigator.vibrate) {
+                navigator.vibrate([200, 100, 200]);
+            }
             setActionDescription('');
         }
     };

--- a/frontend/components/Shared/InstallButton.tsx
+++ b/frontend/components/Shared/InstallButton.tsx
@@ -1,0 +1,37 @@
+import React, { useEffect, useState } from 'react';
+
+const InstallButton: React.FC = () => {
+    const [deferredPrompt, setDeferredPrompt] = useState<any>(null);
+    const [visible, setVisible] = useState(false);
+
+    useEffect(() => {
+        const handler = (e: any) => {
+            e.preventDefault();
+            setDeferredPrompt(e);
+            setVisible(true);
+        };
+        window.addEventListener('beforeinstallprompt', handler);
+        return () => window.removeEventListener('beforeinstallprompt', handler);
+    }, []);
+
+    const handleInstall = async () => {
+        if (!deferredPrompt) return;
+        deferredPrompt.prompt();
+        await deferredPrompt.userChoice;
+        setVisible(false);
+        setDeferredPrompt(null);
+    };
+
+    if (!visible) return null;
+
+    return (
+        <button
+            onClick={handleInstall}
+            className="px-2 py-2 bg-blue-500 hover:bg-blue-600 text-white rounded-full transition"
+        >
+            Install
+        </button>
+    );
+};
+
+export default InstallButton;

--- a/frontend/components/Shared/SubscribeButton.tsx
+++ b/frontend/components/Shared/SubscribeButton.tsx
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+
+const SubscribeButton: React.FC = () => {
+    const [subscribed, setSubscribed] = useState(false);
+
+    const handleSubscribe = async () => {
+        if (!('Notification' in window) || !('serviceWorker' in navigator)) {
+            alert('Push not supported');
+            return;
+        }
+        const permission = await Notification.requestPermission();
+        if (permission !== 'granted') return;
+        const registration = await navigator.serviceWorker.ready;
+        try {
+            const subscription = await registration.pushManager.subscribe({
+                userVisibleOnly: true,
+            });
+            await fetch('/api/push/subscribe', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(subscription),
+            }).catch(() => {});
+            setSubscribed(true);
+        } catch (e) {
+            console.error('Subscribe failed', e);
+        }
+    };
+
+    return (
+        <button
+            onClick={handleSubscribe}
+            disabled={subscribed}
+            className="px-2 py-2 bg-green-500 hover:bg-green-600 text-white rounded-full transition"
+        >
+            {subscribed ? 'Subscribed' : 'Subscribe'}
+        </button>
+    );
+};
+
+export default SubscribeButton;

--- a/frontend/index.tsx
+++ b/frontend/index.tsx
@@ -6,6 +6,19 @@ declare const module: {
 };
 
 import React from 'react';
+
+declare global {
+    interface Document {
+        startViewTransition?: (callback: () => void) => Promise<void>;
+    }
+}
+
+if (!document.startViewTransition) {
+    document.startViewTransition = (callback: () => void) => {
+        callback();
+        return Promise.resolve();
+    };
+}
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
@@ -48,6 +61,14 @@ if (container) {
             </BrowserRouter>
         </I18nextProvider>
     );
+
+    if ('serviceWorker' in navigator) {
+        window.addEventListener('load', () => {
+            navigator.serviceWorker.register('/sw.js').catch((err) => {
+                console.error('SW registration failed', err);
+            });
+        });
+    }
 }
 
 // Hot Module Replacement (HMR) - Remove this snippet to remove HMR.

--- a/public/index.html
+++ b/public/index.html
@@ -5,18 +5,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <base href="/">
     <title>tududi</title>
+    <meta name="theme-color" content="#4a5568">
     <!-- SVG favicon with built-in light/dark mode support -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-    
+
     <!-- Light mode favicon for browsers that support it -->
     <link rel="icon" type="image/x-icon" href="/favicon-light.ico" media="(prefers-color-scheme: light)">
-    
+
     <!-- Dark mode favicon for browsers that support it -->
     <link rel="icon" type="image/x-icon" href="/favicon-dark.ico" media="(prefers-color-scheme: dark)">
-    
+
     <!-- Fallback favicon (medium gray - works reasonably in both modes) -->
     <link rel="shortcut icon" href="/favicon.ico">
-    
+
     <!-- Web app manifest for PWA support -->
     <link rel="manifest" href="/manifest.json">
   </head>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -6,6 +6,7 @@
   "display": "standalone",
   "theme_color": "#4a5568",
   "background_color": "#ffffff",
+  "gcm_sender_id": "103953800507",
   "icons": [
     {
       "src": "/favicon.svg",
@@ -17,6 +18,26 @@
       "src": "/favicon.ico",
       "sizes": "16x16",
       "type": "image/x-icon"
+    }
+  ],
+  "shortcuts": [
+    {
+      "name": "New Note",
+      "short_name": "New Note",
+      "url": "/notes/new",
+      "icons": [{ "src": "/favicon.svg", "sizes": "any", "type": "image/svg+xml" }]
+    },
+    {
+      "name": "Search",
+      "short_name": "Search",
+      "url": "/search",
+      "icons": [{ "src": "/favicon.svg", "sizes": "any", "type": "image/svg+xml" }]
+    },
+    {
+      "name": "Settings",
+      "short_name": "Settings",
+      "url": "/profile",
+      "icons": [{ "src": "/favicon.svg", "sizes": "any", "type": "image/svg+xml" }]
     }
   ]
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,40 @@
+const CACHE_NAME = 'tududi-cache-v1';
+const ASSETS = [
+  '/',
+  '/index.html',
+  '/manifest.json',
+  '/favicon.svg',
+];
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS)).then(() => self.skipWaiting())
+  );
+});
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys => Promise.all(keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k)))).then(() => self.clients.claim())
+  );
+});
+self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.match(event.request).then(res => res || fetch(event.request))
+  );
+});
+self.addEventListener('push', event => {
+  const data = event.data ? event.data.json() : {};
+  const title = data.title || 'tududi';
+  const options = {
+    body: data.body,
+    icon: '/favicon.svg',
+    data: data.url ? { url: data.url } : {},
+  };
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+self.addEventListener('notificationclick', event => {
+  event.notification.close();
+  const url = event.notification.data && event.notification.data.url;
+  if (url) {
+    event.waitUntil(clients.openWindow(url));
+  }
+});


### PR DESCRIPTION
## Summary
- turn `manifest.json` into full PWA manifest with `gcm_sender_id` and shortcuts
- add service worker for caching and push notifications
- register service worker and provide view transition polyfill
- add install and notification subscription buttons to the navbar
- support vibration on important actions
- demo Picture-in-Picture video on the About page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871f00a27b88333b607d729cb27f9cb